### PR TITLE
Fixing Update Logic

### DIFF
--- a/app/src/main/java/com/example/android/unscramble/ui/GameViewModel.kt
+++ b/app/src/main/java/com/example/android/unscramble/ui/GameViewModel.kt
@@ -53,7 +53,7 @@ class GameViewModel : ViewModel() {
      */
     fun resetGame() {
         usedWords.clear()
-        _uiState.value = GameUiState(currentScrambledWord = pickRandomWordAndShuffle())
+        _uiState.value = GameUiState(currentScrambledWord = pickRandomWordAndShuffle(), currentWordCount = 1)
     }
 
     /*
@@ -102,7 +102,6 @@ class GameViewModel : ViewModel() {
             _uiState.update { currentState ->
                 currentState.copy(
                     isGuessedWordWrong = false,
-                    currentWordCount = currentState.currentWordCount.inc(),
                     score = updatedScore,
                     isGameOver = true
                 )


### PR DESCRIPTION
1. On validating the last question, when we don't pick a new question, don't increment the currentWordCount. Updating the currentWordCount, the value updates to 11, where the max_number_of_questions is 10 and hence the test fails.
2. When initializing the ViewModel and setting up the first question, increment the currentWordCount as 1, else the status shows 0 out of 10.

Then the test cases given in the codelab work out of the box.