### PR TITLE
Restore GameViewModelTest.kt (#123)

### DIFF
--- a/app/src/test/java/com/example/unscramble/ui/test/GameViewModelTest.kt
+++ b/app/src/test/java/com/example/unscramble/ui/test/GameViewModelTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c)2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.unscramble.ui.test
+
+import com.example.unscramble.data.MAX_NO_OF_WORDS
+import com.example.unscramble.data.SCORE_INCREASE
+import com.example.unscramble.data.getUnscrambledWord
+import com.example.unscramble.ui.GameViewModel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GameViewModelTest {
+    private val viewModel = GameViewModel()
+
+    @Test
+    fun gameViewModel_Initialization_FirstWordLoaded() {
+        /**
+         *  Warning: This way to retrieve the uiState works because MutableStateFlow is used. In the
+         *  upcoming units you will learn about advanced usages of StateFlow that creates a stream
+         *  of data and you need to react to handle the stream. For those scenarios you will write
+         *  unit tests using different methods/approaches. This applies to all the usages of
+         *  viewModel.uiState.value in this class.
+         **/
+        val gameUiState = viewModel.uiState.value
+        val unScrambledWord = getUnscrambledWord(gameUiState.currentScrambledWord)
+
+        // Assert that current word is scrambled.
+        assertNotEquals(unScrambledWord, gameUiState.currentScrambledWord)
+        // Assert that current word count is set to 1.
+        assertTrue(gameUiState.currentWordCount == 1)
+        // Assert that initially the score is 0.
+        assertTrue(gameUiState.score == 0)
+        // Assert that wrong word guessed is false.
+        assertFalse(gameUiState.isGuessedWordWrong)
+        // Assert that game is not over.
+        assertFalse(gameUiState.isGameOver)
+    }
+
+    @Test
+    fun gameViewModel_IncorrectGuess_ErrorFlagSet() {
+        // Given an incorrect word as input
+        val incorrectPlayerWord = "and"
+
+        viewModel.updateUserGuess(incorrectPlayerWord)
+        viewModel.checkUserGuess()
+
+        val currentGameUiState = viewModel.uiState.value
+        // Assert that score is unchanged
+        assertEquals(0, currentGameUiState.score)
+        // Assert that checkUserGuess() method updates isGuessedWordWrong correctly
+        assertTrue(currentGameUiState.isGuessedWordWrong)
+    }
+
+    @Test
+    fun gameViewModel_CorrectWordGuessed_ScoreUpdatedAndErrorFlagUnset() {
+        var currentGameUiState = viewModel.uiState.value
+        val correctPlayerWord = getUnscrambledWord(currentGameUiState.currentScrambledWord)
+
+        viewModel.updateUserGuess(correctPlayerWord)
+        viewModel.checkUserGuess()
+        currentGameUiState = viewModel.uiState.value
+
+        // Assert that checkUserGuess() method updates isGuessedWordWrong is updated correctly.
+        assertFalse(currentGameUiState.isGuessedWordWrong)
+        // Assert that score is updated correctly.
+        assertEquals(SCORE_AFTER_FIRST_CORRECT_ANSWER, currentGameUiState.score)
+    }
+
+    @Test
+    fun gameViewModel_WordSkipped_ScoreUnchangedAndWordCountIncreased() {
+        var currentGameUiState = viewModel.uiState.value
+        val correctPlayerWord = getUnscrambledWord(currentGameUiState.currentScrambledWord)
+
+        viewModel.updateUserGuess(correctPlayerWord)
+        viewModel.checkUserGuess()
+        currentGameUiState = viewModel.uiState.value
+        val lastWordCount = currentGameUiState.currentWordCount
+
+        viewModel.skipWord()
+        currentGameUiState = viewModel.uiState.value
+        // Assert that score remains unchanged after word is skipped.
+        assertEquals(SCORE_AFTER_FIRST_CORRECT_ANSWER, currentGameUiState.score)
+        // Assert that word count is increased by 1 after word is skipped.
+        assertEquals(lastWordCount + 1, currentGameUiState.currentWordCount)
+    }
+
+    @Test
+    fun gameViewModel_AllWordsGuessed_UiStateUpdatedCorrectly() {
+        var expectedScore = 0
+        var currentGameUiState = viewModel.uiState.value
+        var correctPlayerWord = getUnscrambledWord(currentGameUiState.currentScrambledWord)
+
+        repeat(MAX_NO_OF_WORDS) {
+            expectedScore += SCORE_INCREASE
+            viewModel.updateUserGuess(correctPlayerWord)
+            viewModel.checkUserGuess()
+            currentGameUiState = viewModel.uiState.value
+            correctPlayerWord = getUnscrambledWord(currentGameUiState.currentScrambledWord)
+            // Assert that after each correct answer, score is updated correctly.
+            assertEquals(expectedScore, currentGameUiState.score)
+        }
+        // Assert that after all questions are answered, the current word count is up-to-date.
+        assertEquals(MAX_NO_OF_WORDS, currentGameUiState.currentWordCount)
+        // Assert that after 10 questions are answered, the game is over.
+        assertTrue(currentGameUiState.isGameOver)
+    }
+
+    companion object {
+        private const val SCORE_AFTER_FIRST_CORRECT_ANSWER = SCORE_INCREASE
+    }
+}


### PR DESCRIPTION
Closes [#123](https://github.com/google-developer-training/basic-android-kotlin-compose-training-unscramble/issues/123)

Seems to have been removed in commit 7d2771b8 "Viewmodel Groovy to DSL migration (#108)". This PR just restores `GameViewModelTest.kt`.